### PR TITLE
feature: enable recommended virtual dom lint rules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,8 @@ jobs:
       - name: npm ci
         run: npm ci --ignore-scripts && npm run postinstall
         if: steps.npm-cache.outputs.cache-hit != 'true'
-      - run: npm run type-check
       - run: npm test
+      - run: npm run type-check
       - name: install playwright dependencies
         working-directory: ./packages/e2e
         run: npx playwright install chromium

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,8 +29,8 @@ jobs:
       - name: npm ci
         run: npm ci --ignore-scripts && npm run postinstall
         if: steps.npm-cache.outputs.cache-hit != 'true'
-      - run: npm run type-check
       - run: npm test
+      - run: npm run type-check
       - name: install playwright dependencies
         working-directory: ./packages/e2e
         run: npx playwright install chromium

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,8 +51,8 @@ jobs:
       - name: npm ci
         run: npm ci --ignore-scripts && npm run postinstall
         if: steps.npm-cache.outputs.cache-hit != 'true'
-      - run: npm run type-check
       - run: npm test
+      - run: npm run type-check
       - run: node packages/build/src/build.js
       - name: Build archive
         shell: bash

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,6 +3,7 @@ import * as actions from '@lvce-editor/eslint-plugin-github-actions'
 
 export default [
   ...config.default,
+  ...config.recommendedVirtualDom,
   ...actions.default,
   {
     rules: {

--- a/packages/video-preview-worker/src/parts/DomEventListenerFunctions/DomEventListenerFunctions.ts
+++ b/packages/video-preview-worker/src/parts/DomEventListenerFunctions/DomEventListenerFunctions.ts
@@ -1,0 +1,3 @@
+export const HandleError = 'handleError'
+export const HandleLoadedData = 'handleLoadedData'
+export const HandleTimeUpdate = 'handleTimeUpdate'

--- a/packages/video-preview-worker/src/parts/GetVideoVirtualDom/GetVideoVirtualDom.ts
+++ b/packages/video-preview-worker/src/parts/GetVideoVirtualDom/GetVideoVirtualDom.ts
@@ -1,3 +1,4 @@
+import * as DomEventListenerFunctions from '../DomEventListenerFunctions/DomEventListenerFunctions.ts'
 import * as VirtualDomElements from '../VirtualDomElements/VirtualDomElements.ts'
 
 export const getVideoVirtualDom = (src: string, time: number) => {
@@ -16,9 +17,9 @@ export const getVideoVirtualDom = (src: string, time: number) => {
       className: 'VideoElement',
       controls: true,
       currentTime: time,
-      onError: 'handleError',
-      onLoadedData: 'handleLoadedData',
-      onTimeUpdate: 'handleTimeUpdate',
+      onError: DomEventListenerFunctions.HandleError,
+      onLoadedData: DomEventListenerFunctions.HandleLoadedData,
+      onTimeUpdate: DomEventListenerFunctions.HandleTimeUpdate,
       src,
       type: VirtualDomElements.Video,
     },


### PR DESCRIPTION
Enable the recommended virtual DOM ESLint configuration and replace inline video event-handler strings with registered listener constants.

Also reorder test and type-check steps in CI, PR, and release workflows to satisfy the existing GitHub Actions lint rule surfaced during validation.

Validated with lint, type-check, build, 10 unit tests, and 3 active headless e2e tests.