### PR TITLE
feature: update eslint dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,9 +12,9 @@
         "packages/*"
       ],
       "devDependencies": {
-        "@lvce-editor/eslint-config": "^16.4.0",
+        "@lvce-editor/eslint-config": "^17.5.0",
         "@types/node": "^22.8.1",
-        "eslint": "^10.7.0",
+        "eslint": "^10.8.0",
         "jest": "^30.2.0",
         "prettier": "^3.7.4",
         "ts-jest": "^29.4.11",
@@ -1368,19 +1368,6 @@
         }
       }
     },
-    "node_modules/@e18e/eslint-plugin/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@emnapi/core": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.7.1.tgz",
@@ -1954,9 +1941,9 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
-      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.7.0.tgz",
+      "integrity": "sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2961,11 +2948,14 @@
       }
     },
     "node_modules/@lvce-editor/eslint-config": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-config/-/eslint-config-16.4.0.tgz",
-      "integrity": "sha512-vc382ImEo+upv9LR+kr0vSpfyV8BBxKb+m2nCBVXjGm7eu5Cw9zTPv9X+mxOjWiNkUyWfuwY+NgbgsSC4Scu8g==",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-config/-/eslint-config-17.5.0.tgz",
+      "integrity": "sha512-wjDaVd24PNVZdjbV8EcQYrbEWsKAJ9mak03EUIMTT6+tHVwlg9G1P2eDvqpxyMSmY3ywBKhAPigEjY2pwnCGUQ==",
       "dev": true,
       "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
       "dependencies": {
         "@cspell/eslint-plugin": "10.0.1",
         "@e18e/eslint-plugin": "^0.5.1",
@@ -2973,14 +2963,15 @@
         "@eslint/js": "10.0.1",
         "@eslint/json": "2.0.1",
         "@eslint/markdown": "8.0.3",
-        "@lvce-editor/eslint-plugin-devcontainer": "16.4.0",
-        "@lvce-editor/eslint-plugin-e2e": "16.4.0",
-        "@lvce-editor/eslint-plugin-github-actions": "16.4.0",
-        "@lvce-editor/eslint-plugin-nvmrc": "16.4.0",
-        "@lvce-editor/eslint-plugin-regex": "16.4.0",
-        "@lvce-editor/eslint-plugin-rpc": "16.4.0",
-        "@lvce-editor/eslint-plugin-tsconfig": "16.4.0",
-        "@lvce-editor/eslint-plugin-virtual-dom": "16.4.0",
+        "@lvce-editor/eslint-plugin-devcontainer": "17.5.0",
+        "@lvce-editor/eslint-plugin-e2e": "17.5.0",
+        "@lvce-editor/eslint-plugin-extension-json": "17.5.0",
+        "@lvce-editor/eslint-plugin-github-actions": "17.5.0",
+        "@lvce-editor/eslint-plugin-nvmrc": "17.5.0",
+        "@lvce-editor/eslint-plugin-regex": "17.5.0",
+        "@lvce-editor/eslint-plugin-rpc": "17.5.0",
+        "@lvce-editor/eslint-plugin-tsconfig": "17.5.0",
+        "@lvce-editor/eslint-plugin-virtual-dom": "17.5.0",
         "eslint-plugin-jest": "29.15.4",
         "eslint-plugin-n": "18.2.1",
         "eslint-plugin-package-json": "1.5.0",
@@ -2995,9 +2986,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-devcontainer": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-devcontainer/-/eslint-plugin-devcontainer-16.4.0.tgz",
-      "integrity": "sha512-KWAhBTB5GZrgFoL16rYvY6QI+MHUd5kQ++uFWpV8WE2/pF4RI2xiOTft7lfWUD+EARG9ygyRFbgtVO0RFlFOQw==",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-devcontainer/-/eslint-plugin-devcontainer-17.5.0.tgz",
+      "integrity": "sha512-wNemW3CGngT/bRzB2ldVWW5++V/Xq549Hkbf7ZCc00XGxJhupZKTAYL3qCQvpdT5OJTUFc58Z9ddg42OLVENiQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3005,16 +2996,26 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-e2e": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-e2e/-/eslint-plugin-e2e-16.4.0.tgz",
-      "integrity": "sha512-kS1IGkvUeOZeVUGs+fxSOzGqqXRwWL1dZq1Kq0KHo24gNZ/WqKi2cLVWpAAyQZA+P0dp82SG7WwZ+NZHhPYoSA==",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-e2e/-/eslint-plugin-e2e-17.5.0.tgz",
+      "integrity": "sha512-xGWeOY+aitgaKgxCVeRSJfEWMLf39u5wnq0uA3ZnZKFWXEHpZO3CaJi+9rw7KgFK7TcqgpxsaAHTENYEoabJHQ==",
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@lvce-editor/eslint-plugin-extension-json": {
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-extension-json/-/eslint-plugin-extension-json-17.5.0.tgz",
+      "integrity": "sha512-F7qOAYW1LhFntc2f5Yn1QQqArqgVLi1tW6vRNzgWIptlrZTib0cGFG4jKOL7ZgB5uDl0mZWlZ9q1Q1T055eWhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint/json": "2.0.1"
+      }
+    },
     "node_modules/@lvce-editor/eslint-plugin-github-actions": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-github-actions/-/eslint-plugin-github-actions-16.4.0.tgz",
-      "integrity": "sha512-T66LFDS0nX3/H5nxFiNIkUMEou55FlOxLgOfkbCivZdQQ+fTZnNYb1zOdkxk9hKzQC6RaO4Oj0soilT02TDOQQ==",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-github-actions/-/eslint-plugin-github-actions-17.5.0.tgz",
+      "integrity": "sha512-RhphHPbVQHqRu2yAZ/XnUdpP67BbPrIIrAvdkqSnitCVu65DDTTN1YVZMNdNv8cYue8V3V8eUMIf8WaNFBdJEQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3023,46 +3024,33 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-nvmrc": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-nvmrc/-/eslint-plugin-nvmrc-16.4.0.tgz",
-      "integrity": "sha512-/vx42EiKdt8E7oJ+pbTTKC+V9tgO7yiLKnHlXi664A/s4rEQOfJbB9wq4HYY2hmsDymGokKcNCJNOrdE8GwszA==",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-nvmrc/-/eslint-plugin-nvmrc-17.5.0.tgz",
+      "integrity": "sha512-mYcLlKt8Y2wKlM13xFXKaYDvKDOj/O5nnfj51oW7UTItROxtlD848eaXcxpLrH5iLTW5wC3G3Oz9ftwoGmqq7A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "semver": "^7.8.5"
       }
     },
-    "node_modules/@lvce-editor/eslint-plugin-nvmrc/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@lvce-editor/eslint-plugin-regex": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-regex/-/eslint-plugin-regex-16.4.0.tgz",
-      "integrity": "sha512-XOVlNT6inumz2GLe70A5yuqRvEhGtXe2aCwtCuAnbkD5d1HH5G5NwSA374sF6Z+Kiy02s23eVfxOk+0oh2yQ6g==",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-regex/-/eslint-plugin-regex-17.5.0.tgz",
+      "integrity": "sha512-PER04Hz35vvDFWXPK9wkSyAXB/H5aGGPE6i8nesbmGUP43fqT+7f9Kf5wzRUbUOdZ8HuFcnVQZALMbaEe1NcSg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@lvce-editor/eslint-plugin-rpc": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-rpc/-/eslint-plugin-rpc-16.4.0.tgz",
-      "integrity": "sha512-ghI9uGpUyxPnJnVgKojf0RWTxGnNdmPz/JS4GdvHhw+Kl0cC2OQmvOKLDTSV423hj4WjaUBDqfdeAIZVMq0vLg==",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-rpc/-/eslint-plugin-rpc-17.5.0.tgz",
+      "integrity": "sha512-7dfk74/7pFDK2fWnDK1M8OP46ehlMiK2TlOZYvsg3kU0J4dC0m7emnwvWKCgzyd/rNVPsTyqcz8PSM3U+4Lf4Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@lvce-editor/eslint-plugin-tsconfig": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-tsconfig/-/eslint-plugin-tsconfig-16.4.0.tgz",
-      "integrity": "sha512-tVzMUV7vVy3H6M5kCgDxnL8EXRvDic0+GUb6fmzdsemU/HkA+zlKDbvKs9bfI79hX3EWeptFN2GOXnrGB84MbQ==",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-tsconfig/-/eslint-plugin-tsconfig-17.5.0.tgz",
+      "integrity": "sha512-505lmJeM12Bq5eTZ5FMjB7qmbSu0Xi8bjVCbBSjyMNAVhCAiEUfuWXq0TeiJFeT40GzF88On0GPYHxS+dviWmQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3070,9 +3058,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-virtual-dom": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-virtual-dom/-/eslint-plugin-virtual-dom-16.4.0.tgz",
-      "integrity": "sha512-h0QVBtyzs0/ICLIDBDB1DFzmdvyCHfJB/AFxaonFJ7f6PIrUEFz/HjxvX8jMhcCllRxUrslWqF6DC9Gs76isVw==",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-virtual-dom/-/eslint-plugin-virtual-dom-17.5.0.tgz",
+      "integrity": "sha512-sGiPawCOnR4E/8Bb+NTLlPpmvYS/t2vYrPwoG9/KVUq6gRnj3M34pQw2vsxP9A+PYig5LeL9TX5Wjj//DYVpXA==",
       "dev": true,
       "license": "MIT"
     },
@@ -5783,19 +5771,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -7708,9 +7683,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.7.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.7.0.tgz",
-      "integrity": "sha512-GVTD7s1vdIl6UYvAfriOPeY1Df8LIZjfofLvHwde+erDHGGuHyuM6xoxRxmHiebhYuD2p1vN4wWh0XzPARSGDQ==",
+      "version": "10.8.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.0.tgz",
+      "integrity": "sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
@@ -7720,7 +7695,7 @@
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
         "@eslint/config-array": "^0.23.5",
-        "@eslint/config-helpers": "^0.6.0",
+        "@eslint/config-helpers": "^0.7.0",
         "@eslint/core": "^1.2.1",
         "@eslint/plugin-kit": "^0.7.2",
         "@humanfs/node": "^0.16.6",
@@ -7744,7 +7719,7 @@
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "minimatch": "^10.2.4",
+        "minimatch": "^10.2.5",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -7780,19 +7755,6 @@
       },
       "peerDependencies": {
         "eslint": ">=6.0.0"
-      }
-    },
-    "node_modules/eslint-compat-utils/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/eslint-fix-utils": {
@@ -7874,19 +7836,6 @@
         "eslint": ">=6.0.0"
       }
     },
-    "node_modules/eslint-plugin-es-x/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/eslint-plugin-jest": {
       "version": "29.15.4",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-29.15.4.tgz",
@@ -7953,19 +7902,6 @@
         }
       }
     },
-    "node_modules/eslint-plugin-n/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/eslint-plugin-package-json": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-package-json/-/eslint-plugin-package-json-1.5.0.tgz",
@@ -8022,19 +7958,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eslint-plugin-package-json/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/eslint-plugin-perfectionist": {
@@ -8131,19 +8054,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/eslint-plugin-sonarjs/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/eslint-plugin-unicorn": {
       "version": "71.1.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-71.1.0.tgz",
@@ -8232,19 +8142,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eslint-plugin-unicorn/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/eslint-plugin-unicorn/node_modules/strip-indent": {
@@ -9512,19 +9409,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/istanbul-lib-instrument/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/istanbul-lib-report": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
@@ -10529,19 +10413,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/jest-snapshot/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/jest-util": {
       "version": "30.2.0",
       "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
@@ -11022,19 +10893,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/make-dir/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/make-error": {
@@ -12479,19 +12337,6 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/package-json-validator/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/package-json-validator/node_modules/validate-npm-package-name": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-7.0.2.tgz",
@@ -13269,29 +13114,13 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.5.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.2.tgz",
-      "integrity": "sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
       "bin": {
         "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semver/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
       },
       "engines": {
         "node": ">=10"
@@ -13416,19 +13245,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/sort-package-json/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/sort-package-json/node_modules/tinyglobby": {
@@ -14128,19 +13944,6 @@
         }
       }
     },
-    "node_modules/ts-jest/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/ts-jest/node_modules/type-fest": {
       "version": "4.41.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
@@ -14731,13 +14534,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/yaml": {
       "version": "2.9.0",

--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
     "printWidth": 130
   },
   "devDependencies": {
-    "@lvce-editor/eslint-config": "^16.4.0",
+    "@lvce-editor/eslint-config": "^17.5.0",
     "@types/node": "^22.8.1",
-    "eslint": "^10.7.0",
+    "eslint": "^10.8.0",
     "jest": "^30.2.0",
     "prettier": "^3.7.4",
     "ts-jest": "^29.4.11",

--- a/packages/extension/extension.json
+++ b/packages/extension/extension.json
@@ -4,6 +4,7 @@
   "description": "Video Preview",
   "repository": "https://github.com/lvce-editor/video-preview",
   "browser": "dist/videoPreviewMain.js",
+  "contentSecurityPolicy": ["default-src 'none'", "script-src 'self'"],
   "isolated": true,
   "workerName": "Video Preview Extension Worker",
   "activation": ["onView:builtin.video-preview"],

--- a/packages/extension/src/parts/VideoPreviewView/VideoPreviewView.ts
+++ b/packages/extension/src/parts/VideoPreviewView/VideoPreviewView.ts
@@ -8,7 +8,7 @@ export const view: View<VideoPreviewViewInstance> = {
   eventListeners: [
     {
       name: 'handleVideoError',
-      params: ['handleError', 'event.target.error.code', 'event.target.error.message'],
+      params: ['handleVideoError', 'event.target.error.code', 'event.target.error.message'],
     },
   ],
   id: viewId,

--- a/packages/extension/src/parts/VideoPreviewViewInstance/VideoPreviewViewInstance.ts
+++ b/packages/extension/src/parts/VideoPreviewViewInstance/VideoPreviewViewInstance.ts
@@ -13,7 +13,7 @@ interface SavedState {
 }
 
 export interface VideoPreviewViewInstance extends VirtualDomViewInstance {
-  readonly handleError: (code: unknown, message: unknown) => void
+  readonly handleVideoError: (code: unknown, message: unknown) => void
   readonly render: () => readonly VirtualDomNode[]
   readonly saveState: () => unknown
 }
@@ -41,7 +41,7 @@ export const createInstance = (context?: ViewContext): VideoPreviewViewInstance 
   }
 
   return {
-    handleError(code: unknown, message: unknown): void {
+    handleVideoError(code: unknown, message: unknown): void {
       state = {
         ...state,
         errorMessage: getVideoErrorMessage(code, message),

--- a/packages/extension/test/VideoPreviewViewInstance.test.ts
+++ b/packages/extension/test/VideoPreviewViewInstance.test.ts
@@ -31,7 +31,7 @@ test('saves the video uri', () => {
 test('renders a media error dispatched through a direct view handler', () => {
   const instance = createInstance(createContext())
 
-  instance.handleError(4, 'Format error')
+  instance.handleVideoError(4, 'Format error')
 
   expect(instance.render()[2]).toMatchObject({
     text: 'Failed to decode video: Format error',


### PR DESCRIPTION
## Summary

- update ESLint to 10.8.0
- update `@lvce-editor/eslint-config` to 17.5.0
- configure the extension content security policy
- route video error events through the dedicated view handler

## Validation

- `npm run lint`
- `npm test`
- `npm run type-check`
- `npm run build`
- `node packages/build/src/build-static.js`
- `npm run e2e:headless`
- diagnostic PR #123: 20/20 independent full E2E attempts passed (closed unmerged)